### PR TITLE
Refactor/dry render palette

### DIFF
--- a/palette.js
+++ b/palette.js
@@ -1,5 +1,10 @@
 class Palette {
-  constructor(color0, color1, color2, color3, color4) {
+  constructor() {
+    var color0 = new Color();
+    var color1 = new Color();
+    var color2 = new Color();
+    var color3 = new Color();
+    var color4 = new Color();
     this.colorPalette = [color0, color1, color2, color3, color4];
     this.id = Date.now();
   }

--- a/scripts.js
+++ b/scripts.js
@@ -1,9 +1,4 @@
-var color0 = new Color();
-var color1 = new Color();
-var color2 = new Color();
-var color3 = new Color();
-var color4 = new Color();
-var randomPalette = new Palette(color0, color1, color2, color3, color4);
+var randomPalette = new Palette();
 var savedPalettes = [];
 
 //queryselectors
@@ -12,11 +7,15 @@ var box1 = document.querySelector("#box1");
 var box2 = document.querySelector("#box2");
 var box3 = document.querySelector("#box3");
 var box4 = document.querySelector("#box4");
+var boxes = [box0, box1, box2, box3, box4];
+
 var hexCode0 = document.querySelector("#hex0");
 var hexCode1 = document.querySelector("#hex1");
 var hexCode2 = document.querySelector("#hex2");
 var hexCode3 = document.querySelector("#hex3");
 var hexCode4 = document.querySelector("#hex4");
+var hexCodes = [hexCode0, hexCode1, hexCode2, hexCode3, hexCode4];
+
 var newPaletteButton = document.querySelector("#new-palette-button");
 var savePaletteButton = document.querySelector("#save-palette-button");
 var savedPaletteSection = document.querySelector(".saved-palettes");
@@ -39,35 +38,17 @@ savePaletteButton.addEventListener("click", function() {
 })
 
 //functions
-function showPalette(randomPalette) {
-createPalette(randomPalette);
-}
-
-function createPalette(palette) {
-    box0.style.backgroundColor = palette.colorPalette[0].color;
-    box1.style.backgroundColor = palette.colorPalette[1].color;
-    box2.style.backgroundColor = palette.colorPalette[2].color;
-    box3.style.backgroundColor = palette.colorPalette[3].color;
-    box4.style.backgroundColor = palette.colorPalette[4].color;
-    hexCode0.innerText = palette.colorPalette[0].color;
-    hexCode1.innerText = palette.colorPalette[1].color;
-    hexCode2.innerText = palette.colorPalette[2].color;
-    hexCode3.innerText = palette.colorPalette[3].color;
-    hexCode4.innerText = palette.colorPalette[4].color;    
+function showPalette(palette) {
+    // boxes and hexCodes have the same length
+    for (var i = 0; i < boxes.length; i++) {
+        boxes[i].style.backgroundColor = palette.colorPalette[i].color;
+        hexCodes[i].innerText = palette.colorPalette[i].color;
+    }
 }
 
 function replaceColor(palette) {
     palette.replaceColors();
-    box0.style.backgroundColor = palette.colorPalette[0].color;
-    box1.style.backgroundColor = palette.colorPalette[1].color;
-    box2.style.backgroundColor = palette.colorPalette[2].color;
-    box3.style.backgroundColor = palette.colorPalette[3].color;
-    box4.style.backgroundColor = palette.colorPalette[4].color;
-    hexCode0.innerText = palette.colorPalette[0].color;
-    hexCode1.innerText = palette.colorPalette[1].color;
-    hexCode2.innerText = palette.colorPalette[2].color;
-    hexCode3.innerText = palette.colorPalette[3].color;
-    hexCode4.innerText = palette.colorPalette[4].color;
+    showPalette(palette);
 }
 
 function savePalette(palette, paletteArray) {
@@ -81,7 +62,7 @@ function displaySavedPalettes(paletteArray) {
     savedMiniPalettes.innerHTML = ""
     for (var i = 0; i < paletteArray.length; i++) {
         savedMiniPalettes.innerHTML += `
-         <section class="saved-mini-palette">
+        <section class="saved-mini-palette">
               <div class="box mini" id="mini-box0" style= "background-color: ${paletteArray[i].colorPalette[0].color};"></div>
               <div class="box mini" id="mini-box1" style= "background-color: ${paletteArray[i].colorPalette[1].color};"></div>
               <div class="box mini" id="mini-box2" style= "background-color: ${paletteArray[i].colorPalette[2].color};"></div>
@@ -91,12 +72,8 @@ function displaySavedPalettes(paletteArray) {
         </section>
        `;        
     }
-    color0 = new Color();
-    color1 = new Color();
-    color2 = new Color();
-    color3 = new Color();
-    color4 = new Color();
-    randomPalette = new Palette(color0, color1, color2, color3, color4);
+
+    randomPalette = new Palette();
     showPalette(randomPalette);
 }
 


### PR DESCRIPTION
I made the code DRYer by:
-creating an array for the box0-box4 variables to live in.
-creating an array for the hexcode0-hexcode4 to live in.
-instantiating the Color class 5 times **inside** the Palette class. (This keeps us from having to instantiate the Color class 5 times at the beginning of our scripts file and also inside the savePalette function, instead we can just instantiate palette once at the beginning and once in the savePalette function)
-utilizing a for loop to loop through the boxes and hexcodes arrays when reassigning the innertext and the style.backgroundcolor.
-calling the showPalette function inside the replacePallete function (the lines of code were the same)