### PR TITLE
Bugfix/lock-colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,53 +13,55 @@
 <body>
     <section class="random-palette">
         <h1>COLORANDOM</h1>
-        <section id="color-boxes">
-            <section id="color0">
-                <div class="box" id="box0">
-                </div>
-                <div class="hex-and-lock">
-                    <p id="hex0"></p>
-                    <img class="unlock-icon" data-unlock="0" src="unlock image.png">
-                    <img class="lock-icon hidden" data-lock="0" src="locked image.png">
-                </div>
+        <div id="main-palette-container">
+            <section id="color-boxes">
+                <section id="color0">
+                    <div class="box" id="box0">
+                    </div>
+                    <div class="hex-and-lock">
+                        <p id="hex0"></p>
+                        <img class="unlock-icon" data-unlock="0" src="unlock image.png">
+                        <img class="lock-icon hidden" data-lock="0" src="locked image.png">
+                    </div>
+                </section>
+                <section id="color1">
+                    <div class="box" id="box1">
+                    </div>
+                    <div class="hex-and-lock">
+                        <p id="hex1"></p>
+                        <img class="unlock-icon" data-unlock="1" src="unlock image.png">
+                        <img class="lock-icon hidden" data-lock="1" src="locked image.png">
+                    </div>
+                </section>
+                <section id="color2">
+                    <div class="box" id="box2">
+                    </div>
+                    <div class="hex-and-lock">
+                        <p id="hex2"></p>
+                        <img class="unlock-icon" data-unlock="2" src="unlock image.png">
+                        <img class="lock-icon hidden" data-lock="2" src="locked image.png">
+                    </div>
+                </section>
+                <section id="color3">
+                    <div class="box" id="box3">
+                    </div>
+                    <div class="hex-and-lock">
+                        <p id="hex3"></p>
+                        <img class="unlock-icon" data-unlock="3" src="unlock image.png">
+                        <img class="lock-icon hidden" data-lock="3" src="locked image.png">
+                    </div>
+                </section>
+                <section id="color4">
+                    <div class="box" id="box4">
+                    </div>
+                    <div class="hex-and-lock">
+                        <p id="hex4"></p>
+                        <img class="unlock-icon" data-unlock="4" src="unlock image.png">
+                        <img class="lock-icon hidden" data-lock="4" src="locked image.png">
+                    </div>
+                </section>
             </section>
-            <section id="color1">
-                <div class="box" id="box1">
-                </div>
-                <div class="hex-and-lock">
-                    <p id="hex1"></p>
-                    <img class="unlock-icon" data-unlock="1" src="unlock image.png">
-                    <img class="lock-icon hidden" data-lock="1" src="locked image.png">
-                </div>
-            </section>
-            <section id="color2">
-                <div class="box" id="box2">
-                </div>
-                <div class="hex-and-lock">
-                    <p id="hex2"></p>
-                    <img class="unlock-icon" data-unlock="2" src="unlock image.png">
-                    <img class="lock-icon hidden" data-lock="2" src="locked image.png">
-                </div>
-            </section>
-            <section id="color3">
-                <div class="box" id="box3">
-                </div>
-                <div class="hex-and-lock">
-                    <p id="hex3"></p>
-                    <img class="unlock-icon" data-unlock="3" src="unlock image.png">
-                    <img class="lock-icon hidden" data-lock="3" src="locked image.png">
-                </div>
-            </section>
-            <section id="color4">
-                <div class="box" id="box4">
-                </div>
-                <div class="hex-and-lock">
-                    <p id="hex4"></p>
-                    <img class="unlock-icon" data-unlock="4" src="unlock image.png">
-                    <img class="lock-icon hidden" data-lock="4" src="locked image.png">
-                </div>
-            </section>
-        </section>
+        </div>
         <section class="main-buttons-section">
             <button id="new-palette-button">New Palette</button>
             <button id="save-palette-button">Save Palette</button>
@@ -74,6 +76,7 @@
     <script src="palette.js"></script>
     <script src="scripts.js"></script>
 </body>
+
 </html>
 
 <!-- Add saved palettes section.

--- a/scripts.js
+++ b/scripts.js
@@ -27,7 +27,7 @@ var miniBox3 = document.querySelector("#mini-box3");
 var miniBox4 = document.querySelector("#mini-box4");
 var lockIcons = document.querySelectorAll(".lock-icon");
 var unlockIcons = document.querySelectorAll(".unlock-icon")
-var paletteContainer = document.querySelector(".random-palette");
+var mainPaletteContainer = document.querySelector("#main-palette-container");
 var savedPalettesSection = document.querySelector("#saved-palettes-container");
 
 //listeners
@@ -43,15 +43,12 @@ savePaletteButton.addEventListener("click", function () {
     showPalette(randomPalette);
 })
 
-paletteContainer.addEventListener("click", function (event) {
+mainPaletteContainer.addEventListener("click", function (event) {
     toggleColorLock(event, randomPalette);
 })
 savedPalettesSection.addEventListener('click', function(event) {
     deleteSavedPalette(event, savedPalettes)
 })
-
-
-
 
 //functions
 function showPalette(palette) {
@@ -91,8 +88,11 @@ function displaySavedPalettes(paletteArray) {
 }
 
 function toggleColorLock(event, palette) {
-    palette.toggleLock(event.target.dataset.colorIndex);
-    updateIcon(event, palette);
+    if (event.target.dataset.colorIndex) {
+        palette.toggleLock(event.target.dataset.colorIndex);
+        updateIcon(event, palette);
+    }
+    
 }
 
 function updateIcon(event, palette) {


### PR DESCRIPTION
-  We had a bug that caused the toggleLockIcon function to fire when clicking on the background or the save palette button due to the event listener being on the grandparent. 
- This adds a container wrapping around the main palette section and it excludes the buttons.
-  We added an if state to the toggleLockIcon requiring a specific data attribute to be present (colorIndex) to fire the function.

Comments/Questions:
- We need to fix the bug the is causing the lock icon to not toggle when a palette is either saved or a new one is displayed on the page