### PR TITLE
Fix: the lock icons to reset once clicking the save palette button

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -64,11 +64,21 @@ function replaceColor(palette) {
     showPalette(palette);
 }
 
+function resetLocks(palette) {
+    for(var i = 0; i < palette.colorPalette.length; i++) {
+        if(!palette.colorPalette.locked) {
+        lockIcons[i].classList.add("hidden");
+        unlockIcons[i].classList.remove("hidden");
+        }
+    }
+}
+
 function savePalette(palette, paletteArray) {
     if (!paletteArray.includes(palette)) {
         paletteArray.push(palette);
     }
     displaySavedPalettes(paletteArray);
+    resetLocks(palette);
 }
 
 function displaySavedPalettes(paletteArray) {
@@ -106,12 +116,14 @@ function updateIcon(event, palette) {
 }
 
 function deleteSavedPalette(event, paletteArray) {
-
     if(event.target.classList.contains("trash")) {
         paletteArray.splice(event.target.parentElement.dataset.paletteIndex, 1) 
         displaySavedPalettes(paletteArray);
     }
 }
+
+
+
 
 
 


### PR DESCRIPTION
- We created a new function that loops through the colors array and identifies if the color is locked or unlocked and resets 
any 'locked' icon to unlocked once the user clicks the 'Saved Palette' button. We called the new function within our savePalette function.
- I don't personally see any additional bugs, but mess around with the app and try and break the code. 

- We do want to fix the responsiveness of the page, the buttons, palettes, text all don't adjust the intended way we want. 
- Add hover state for all the buttons, color boxes, and trash can
- Let's do some independent research on possible refactoring for css, html and Javascript
- Let's dig deeper into the HTML and delete any unused classes, id's, etc.
*** Don't forget the README ***